### PR TITLE
Reproduce fake line overlap issue

### DIFF
--- a/tests/simple_test_1.rs
+++ b/tests/simple_test_1.rs
@@ -64,6 +64,31 @@ fn two_connected_3() -> Result<(), intersect2d::IntersectError> {
     Ok(())
 }
 
+
+#[test]
+fn two_connected_4() -> Result<(), intersect2d::IntersectError> {
+    let intersection = intersect(
+            &geo::Line::new(
+                geo::Coordinate{ x: 0.0, y: 0.0 },
+                geo::Coordinate{ x: 0.0, y: 100.0 },
+            ),
+            &geo::Line::new(
+                geo::Coordinate{ x: 0.0, y: 100.0 },
+                geo::Coordinate{ x: 0.0, y: 200.0 },
+            ),
+        );
+    println!("intersection: {:?}", intersection);
+    assert!(
+        matches!(
+            intersection.expect("lines should intersect"),
+            intersect2d::Intersection::Intersection(coord)
+            if coord == geo::Coordinate{ x: 0.0, y: 100.0 }
+        )
+    );
+    Ok(())
+}
+
+
 //#[ignore]
 #[test]
 fn connected_3_1() -> Result<(), intersect2d::IntersectError> {


### PR DESCRIPTION
No fix yet, contributing a failing test:

```
    let intersection = intersect(
            &geo::Line::new(
                geo::Coordinate{ x: 0.0, y: 0.0 },
                geo::Coordinate{ x: 0.0, y: 100.0 },
            ),
            &geo::Line::new(
                geo::Coordinate{ x: 0.0, y: 100.0 },
                geo::Coordinate{ x: 0.0, y: 200.0 },
            ),
        );
    println!("intersection: {:?}", intersection);
```

I would expect it to give one overlapping point: (0.0, 100.0)

```
intersection: Some(Line { start: Coord { x: 0.0, y: 100.0 }, end: Coord { x: 0.0, y: 200.0 } })
tests/simple_test_1.rs|81 col 5| assertion failed: matches!(intersection.expect(\"lines should intersect\"), intersect2d ::\n    Intersection :: Intersection(coord) if coord == geo :: Coordinate\n    { x : 0.0, y : 100.0 })
```